### PR TITLE
Encode attachments as `base64` strings when sending via Graph API

### DIFF
--- a/services/protocols/MS-Graph-API.js
+++ b/services/protocols/MS-Graph-API.js
@@ -183,10 +183,11 @@ async function _generateMsGraphApiEmailProperties(email) {
   const attachmentsData = await fetchAttachmentsForEmail(email.email);
   for (const attachment of attachmentsData) {
     const contentBytes = fs.readFileSync(attachment.path);
+    const base64Encoded = contentBytes.toString('base64');
 
     const attachmentData = {
       "@odata.type": "#microsoft.graph.fileAttachment",
-      contentBytes: contentBytes,
+      contentBytes: base64Encoded,
     };
 
     if (attachment.filename) {


### PR DESCRIPTION
Apparently you need to encode attachment files as base64 for sending via Graph API, a detail I missed back when implementing this.

Thanks to Sven for catching the issue and helping with fixing it!