### PR TITLE
Add support for large attachments via Graph API

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ The following environment variables can be added to your docker-compose file. Yo
 | ENV  | Description | default | required |
 |---|---|---|---|
 | NODE_ENV  | Choose your node environment. options: "production" or "development"   | "production" | |
+| LOG_MS_GRAPH_API_REQUESTS | whether to log all the requests sent to the Microsoft Graph API | false |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ deliver-email-service:
 ## Attachments
 
 Attachments are linked through  `nmo:hasAttachment` property on the email. 
-The model of the attachment itself is based on [NEPOMUK](http://oscaf.sourceforge.net/nmo.html#nmo:hasAttachment) and the conventions used for the [mu-semtech/file-service](https://github.com/mu-semtech/file-service)
+The model of the attachment itself is based on [NEPOMUK](http://oscaf.sourceforge.net/nmo.html#nmo:hasAttachment) and the conventions used for the [mu-semtech/file-service](https://github.com/mu-semtech/file-service).
+
+Note that when using the Graph API to send attachments there's a hard limit of 150 MB per file. The service won't attach larger files to emails. Other size restrictions apply to the total size of the email, these based on the mail provider's settings. In general, 35 MB is the max total size (i.e. the sum size of all the attachments and the email itself) for emails sent via the Graph API
 
 # Example Structure
 

--- a/config.js
+++ b/config.js
@@ -1,6 +1,7 @@
 import { ClientSecretCredential } from "@azure/identity";
 import { TokenCredentialAuthenticationProvider } from "@microsoft/microsoft-graph-client/authProviders/azureTokenCredentials";
 
+const NODE_ENV = process.env.NODE_ENV;
 const MAILBOX_URI = process.env.MAILBOX_URI;
 const EMAIL_PROTOCOL = process.env.EMAIL_PROTOCOL || 'smtp';
 const FROM_NAME = process.env.FROM_NAME || '';
@@ -120,5 +121,6 @@ export {
   PORT,
   NODE_MAILER_SERVICES,
   MS_GRAPH_API_AUTH_PROVIDER,
-  MS_GRAPH_API_EMAIL_RETRIEVE_WAIT_TIME
+  MS_GRAPH_API_EMAIL_RETRIEVE_WAIT_TIME,
+  NODE_ENV,
 };

--- a/config.js
+++ b/config.js
@@ -1,7 +1,6 @@
 import { ClientSecretCredential } from "@azure/identity";
 import { TokenCredentialAuthenticationProvider } from "@microsoft/microsoft-graph-client/authProviders/azureTokenCredentials";
 
-const NODE_ENV = process.env.NODE_ENV;
 const MAILBOX_URI = process.env.MAILBOX_URI;
 const EMAIL_PROTOCOL = process.env.EMAIL_PROTOCOL || 'smtp';
 const FROM_NAME = process.env.FROM_NAME || '';
@@ -23,6 +22,7 @@ const MS_GRAPH_API_CLIENT_ID = process.env.MS_GRAPH_API_CLIENT_ID;
 const MS_GRAPH_API_TENANT_ID = process.env.MS_GRAPH_API_TENANT_ID;
 const MS_GRAPH_API_CLIENT_SECRET = process.env.MS_GRAPH_API_CLIENT_SECRET;
 const MS_GRAPH_API_EMAIL_RETRIEVE_WAIT_TIME = process.env.MS_GRAPH_API_EMAIL_RETRIEVE_WAIT_TIME || 10000;
+const LOG_MS_GRAPH_API_REQUESTS = ["true", "yes", "1", "on"].includes(process.env.LOG_MS_GRAPH_API_REQUESTS);
 
 let MS_GRAPH_API_CREDENTIAL;
 let MS_GRAPH_API_AUTH_PROVIDER;
@@ -122,5 +122,5 @@ export {
   NODE_MAILER_SERVICES,
   MS_GRAPH_API_AUTH_PROVIDER,
   MS_GRAPH_API_EMAIL_RETRIEVE_WAIT_TIME,
-  NODE_ENV,
+  LOG_MS_GRAPH_API_REQUESTS,
 };

--- a/services/protocols/MS-Graph-API.js
+++ b/services/protocols/MS-Graph-API.js
@@ -5,7 +5,7 @@ import moveEmailToFolder from "../../queries/move-email-to-folder";
 import ensureSentDate from "../../utils/ensure-sent-date";
 import fetchAttachmentsForEmail from "../../queries/fetch-attachments-for-email";
 import {
-  NODE_ENV,
+  LOG_MS_GRAPH_API_REQUESTS,
   EMAIL_ADDRESS,
   MAILBOX_URI,
   MS_GRAPH_API_AUTH_PROVIDER,
@@ -52,7 +52,7 @@ async function _sendMail(email, count) {
   await sendOrRetry(async () => {
     const client = Client.initWithMiddleware({
       authProvider: MS_GRAPH_API_AUTH_PROVIDER,
-      debugLogging: NODE_ENV === "development",
+      debugLogging: LOG_MS_GRAPH_API_REQUETS,
     });
 
 

--- a/services/protocols/MS-Graph-API.js
+++ b/services/protocols/MS-Graph-API.js
@@ -52,7 +52,7 @@ async function _sendMail(email, count) {
   await sendOrRetry(async () => {
     const client = Client.initWithMiddleware({
       authProvider: MS_GRAPH_API_AUTH_PROVIDER,
-      debugLogging: LOG_MS_GRAPH_API_REQUETS,
+      debugLogging: LOG_MS_GRAPH_API_REQUESTS,
     });
 
 

--- a/services/protocols/MS-Graph-API.js
+++ b/services/protocols/MS-Graph-API.js
@@ -1,10 +1,11 @@
 import fs from "fs";
-import { Client } from "@microsoft/microsoft-graph-client";
+import { Client, StreamUpload, LargeFileUploadTask } from "@microsoft/microsoft-graph-client";
 import "isomorphic-fetch";
 import moveEmailToFolder from "../../queries/move-email-to-folder";
 import ensureSentDate from "../../utils/ensure-sent-date";
 import fetchAttachmentsForEmail from "../../queries/fetch-attachments-for-email";
 import {
+  NODE_ENV,
   EMAIL_ADDRESS,
   MAILBOX_URI,
   MS_GRAPH_API_AUTH_PROVIDER,
@@ -51,7 +52,9 @@ async function _sendMail(email, count) {
   await sendOrRetry(async () => {
     const client = Client.initWithMiddleware({
       authProvider: MS_GRAPH_API_AUTH_PROVIDER,
+      debugLogging: NODE_ENV === "development",
     });
+
 
     const mailProperties = await _generateMsGraphApiEmailProperties(email);
 
@@ -72,6 +75,9 @@ async function _sendMail(email, count) {
       userPrincipalName,
       mailProperties
     );
+
+    // Add attachments
+    await _addAttachmentsToEmail(client, userPrincipalName, immutableId, email.email);
 
     // Send draft
     await _sendDraftEmail(client, userPrincipalName, immutableId);
@@ -179,27 +185,6 @@ async function _getSentEmail(
 }
 
 async function _generateMsGraphApiEmailProperties(email) {
-  const attachments = [];
-  const attachmentsData = await fetchAttachmentsForEmail(email.email);
-  for (const attachment of attachmentsData) {
-    const contentBytes = fs.readFileSync(attachment.path);
-    const base64Encoded = contentBytes.toString('base64');
-
-    const attachmentData = {
-      "@odata.type": "#microsoft.graph.fileAttachment",
-      contentBytes: base64Encoded,
-    };
-
-    if (attachment.filename) {
-      attachmentData.name = attachment.filename;
-    }
-    if (attachment.contentType) {
-      attachmentData.contentType = attachment.contentType;
-    }
-
-    attachments.push(attachmentData);
-  }
-
   const body = {};
   if (email.htmlMessageContent) {
     body.contentType = "HTML";
@@ -235,10 +220,68 @@ async function _generateMsGraphApiEmailProperties(email) {
     replyTo: splitEmailString(email.replyTo),
     subject: email.messageSubject,
     body: body,
-    attachments: attachments,
   };
 
   return mailProperties;
+}
+
+async function _addAttachmentsToEmail(client, userPrincipalName, immutableId, emailUri) {
+  const ATTACHMENT_CUTOFF_SIZE = 3 * 1000000;
+  const ATTACHMENT_MAX_SIZE = 150 * 1000000;
+
+  const attachments = await fetchAttachmentsForEmail(emailUri);
+  for (const attachment of attachments) {
+    const fileStats = fs.statSync(attachment.path);
+    const fileSize = fileStats.size;
+    const fileName = attachment.filename ?? 'Attachment';
+
+    // Files smaller than 3MB in size can be attached directly to a message
+    // Larger files must be uploaded via an uploadSession
+    if (fileSize < ATTACHMENT_CUTOFF_SIZE) {
+      const contentBytes = fs.readFileSync(attachment.path);
+      const base64Encoded = contentBytes.toString('base64');
+      const attachmentData = {
+        "@odata.type": "#microsoft.graph.fileAttachment",
+        contentBytes: base64Encoded,
+        name: fileName,
+      };
+      if (attachment.contentType) {
+        attachmentData.contentType = attachment.contentType;
+      }
+      await client
+        .api(`/users/${userPrincipalName}/mailFolders/sentitems/messages/${immutableId}/attachments`)
+        .post(attachmentData);
+    } else if (fileSize < ATTACHMENT_MAX_SIZE) {
+      const uploadSessionPayload = {
+        AttachmentItem: {
+          attachmentType: 'file',
+          name: fileName,
+          size: fileSize,
+        }
+      }
+      if (attachment.contentType) {
+        uploadSessionPayload.AttachmentItem.contentType = attachment.contentType;
+      }
+      const uploadSession = await LargeFileUploadTask.createUploadSession(
+        client,
+        `/users/${userPrincipalName}/mailFolders/sentitems/messages/${immutableId}/attachments/createUploadSession`,
+        uploadSessionPayload,
+      );
+      const readStream = fs.createReadStream(attachment.path);
+      const fileObject = new StreamUpload(readStream, fileName, fileSize);
+      const options = {
+        rangeSize: 327680,
+        uploadEventHandlers: {
+          progress: (range) => { console.info(`Progress uploading attachment <${attachment.attachment}>. Bytes: [${range.minValue}, ${range.maxValue}]`) }
+        },
+      };
+      const uploadTask = new LargeFileUploadTask(client, fileObject, uploadSession, options);
+      await uploadTask.upload();
+    } else {
+      console.warn(`Attachment <${attachment.attachment}> for email <${emailUri}> is too large to be sent as attachment. File size (in bytes): ${fileStats.size}`);
+    }
+
+  }
 }
 
 export default sendMSGraphAPI;


### PR DESCRIPTION
Attachments larger that 3MB get uploaded via an uploadSession instead of being directly attached to messages.

Note: the max attachments size is 150MB, Graph API does not support any files larger than that. Currently, the service just sends the email without the attachment if it finds a file that's too large. If desired, we can make the service send the mail to the failbox instead.

:warning: Max attachment size is in practice dependent on the AD (apparently you can choose the max file size of attachments) as well as the receiver. You could in practice be sending emails that never arrive even if Graph API says it's ok due to file size restrictions.