### PR TITLE
feat | Set docker javascript-template:feature-node-18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM semtech/mu-javascript-template:1.4.0
+FROM semtech/mu-javascript-template:feature-node-18
 LABEL maintainer=info@redpencil.io


### PR DESCRIPTION
Got this error when running the service
```bash
deliver-email-1  | Debugger listening on ws://0.0.0.0:9229/08708712-9461-458b-a62e-08efb0210630
deliver-email-1  | For help, see: https://nodejs.org/en/docs/inspector
deliver-email-1  | internal/modules/cjs/loader.js:985
deliver-email-1  |   throw err;
deliver-email-1  |   ^
deliver-email-1  |
deliver-email-1  | Error: Cannot find module 'node:os'
deliver-email-1  | Require stack:
```

Updated the node version to 18